### PR TITLE
Setup initial Django backend and React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+venv/
+
+# Node
+node_modules/
+.dist/
+
+# Env
+.env
+
+# Frontend build
+frontend/dist/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# grooice
+# Grooice
+
+Prototype grocery receipt tracker with a Django REST backend and React frontend.
+
+## Open Data
+- [Open Food Facts](https://world.openfoodfacts.org/) provides a large open database of food products, including many sold on the Italian market.
+
+## Backend
+Located in [`backend/`](backend/), the Django project exposes a basic `/api/items/` endpoint.
+
+## Frontend
+Located in [`frontend/`](frontend/), the React app is bootstrapped with Vite and styled with Tailwind CSS.
+The demo component fetches items from the Django API and lists them.

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,0 +1,1 @@
+# Config package for Django project

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+application = get_asgi_application()

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = 'replace-this-secret-key'
+
+DEBUG = True
+ALLOWED_HOSTS = []
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'corsheaders',
+    'receipts',
+]
+
+MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'config.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'config.wsgi.application'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = []
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = 'static/'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Allow frontend dev server to access the API during development
+CORS_ALLOW_ALL_ORIGINS = True

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,0 +1,12 @@
+from django.contrib import admin
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from receipts.views import ItemViewSet
+
+router = DefaultRouter()
+router.register(r'items', ItemViewSet)
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('api/', include(router.urls)),
+]

--- a/backend/config/wsgi.py
+++ b/backend/config/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+application = get_wsgi_application()

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import os
+import sys
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Django is not installed. Please install the dependencies to run this project."
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/backend/receipts/__init__.py
+++ b/backend/receipts/__init__.py
@@ -1,0 +1,1 @@
+# Receipts application

--- a/backend/receipts/admin.py
+++ b/backend/receipts/admin.py
@@ -1,0 +1,4 @@
+from django.contrib import admin
+from .models import Store, Category, Item, StoreItemAlias, Receipt, ReceiptLineItem
+
+admin.site.register([Store, Category, Item, StoreItemAlias, Receipt, ReceiptLineItem])

--- a/backend/receipts/apps.py
+++ b/backend/receipts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ReceiptsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'receipts'

--- a/backend/receipts/migrations/0001_initial.py
+++ b/backend/receipts/migrations/0001_initial.py
@@ -1,0 +1,61 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Store',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100, unique=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Category',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100, unique=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Item',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=200, unique=True)),
+                ('category', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, to='receipts.category')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='StoreItemAlias',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('alias_name', models.CharField(max_length=200)),
+                ('canonical_item', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='receipts.item')),
+                ('store', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='receipts.store')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Receipt',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('datetime', models.DateTimeField()),
+                ('raw_text', models.TextField(blank=True)),
+                ('store', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='receipts.store')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='ReceiptLineItem',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('quantity', models.DecimalField(decimal_places=2, default=1, max_digits=10)),
+                ('price_total', models.DecimalField(decimal_places=2, max_digits=10)),
+                ('receipt', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='receipts.receipt')),
+                ('store_item_alias', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='receipts.storeitemalias')),
+            ],
+        ),
+    ]

--- a/backend/receipts/migrations/__init__.py
+++ b/backend/receipts/migrations/__init__.py
@@ -1,0 +1,1 @@
+# Migrations package

--- a/backend/receipts/models.py
+++ b/backend/receipts/models.py
@@ -1,0 +1,51 @@
+from django.db import models
+
+
+class Store(models.Model):
+    name = models.CharField(max_length=100, unique=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Category(models.Model):
+    name = models.CharField(max_length=100, unique=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Item(models.Model):
+    name = models.CharField(max_length=200, unique=True)
+    category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True)
+
+    def __str__(self):
+        return self.name
+
+
+class StoreItemAlias(models.Model):
+    store = models.ForeignKey(Store, on_delete=models.CASCADE)
+    alias_name = models.CharField(max_length=200)
+    canonical_item = models.ForeignKey(Item, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return f"{self.store.name}: {self.alias_name}"
+
+
+class Receipt(models.Model):
+    store = models.ForeignKey(Store, on_delete=models.CASCADE)
+    datetime = models.DateTimeField()
+    raw_text = models.TextField(blank=True)
+
+    def __str__(self):
+        return f"Receipt {self.pk} at {self.store.name}"
+
+
+class ReceiptLineItem(models.Model):
+    receipt = models.ForeignKey(Receipt, on_delete=models.CASCADE)
+    store_item_alias = models.ForeignKey(StoreItemAlias, on_delete=models.PROTECT)
+    quantity = models.DecimalField(max_digits=10, decimal_places=2, default=1)
+    price_total = models.DecimalField(max_digits=10, decimal_places=2)
+
+    def __str__(self):
+        return f"{self.store_item_alias.alias_name} x{self.quantity}"

--- a/backend/receipts/serializers.py
+++ b/backend/receipts/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import Item
+
+
+class ItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Item
+        fields = ['id', 'name', 'category']

--- a/backend/receipts/tests.py
+++ b/backend/receipts/tests.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from .models import Category, Item
+
+
+class ItemModelTest(TestCase):
+    def test_create_item(self):
+        cat = Category.objects.create(name="Dairy")
+        item = Item.objects.create(name="Milk 1L", category=cat)
+        self.assertEqual(item.category.name, "Dairy")

--- a/backend/receipts/views.py
+++ b/backend/receipts/views.py
@@ -1,0 +1,8 @@
+from rest_framework import viewsets
+from .models import Item
+from .serializers import ItemSerializer
+
+
+class ItemViewSet(viewsets.ModelViewSet):
+    queryset = Item.objects.all()
+    serializer_class = ItemSerializer

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+Django>=5.0,<5.1
+djangorestframework>=3.14,<4.0
+django-cors-headers>=4.3,<5.0

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Grooice</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "grooice-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.1.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+export default function App() {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/api/items/')
+      .then((res) => res.json())
+      .then((data) => setItems(data))
+      .catch(() => {
+        // ignore errors in this simple demo
+      });
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-100 p-4">
+      <h1 className="text-2xl font-bold mb-4 text-center">Grooice Demo</h1>
+      <div className="max-w-md mx-auto bg-white shadow rounded-lg">
+        <ul>
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="flex justify-between px-4 py-2 border-b last:border-b-0"
+            >
+              <span>{item.name}</span>
+              <span className="text-gray-500">{item.category ?? '—'}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="p-4 text-right">
+          <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+            Add Item
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Django backend with receipt, item, store models and basic API endpoint
- add React + Vite frontend scaffold with Tailwind-styled demo component
- enable CORS and fetch items from API in the demo

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<5.1,>=5.0)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f68b09d38832da6361ab86f189c51